### PR TITLE
fix: add landmark roles and semantic tags for accessibility

### DIFF
--- a/.vitepress/theme/components/SiteFooter.vue
+++ b/.vitepress/theme/components/SiteFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="site-footer">&copy; Kazumi Inada</footer>
+  <footer class="site-footer" role="contentinfo">&copy; Kazumi Inada</footer>
 </template>
 
 <style lang="scss" scoped>

--- a/.vitepress/theme/components/SiteHeader.vue
+++ b/.vitepress/theme/components/SiteHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="site-header">
+  <header class="site-header" role="banner">
     <a href="https://www.nandenjin.com" class="logo">Kazumi Inada</a>
     <div class="back">
       <a href="https://www.nandenjin.com">Back to Portfolio</a>

--- a/.vitepress/theme/layouts/Layout.vue
+++ b/.vitepress/theme/layouts/Layout.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <SiteHeader />
-    <div class="theme-content">
+    <main class="theme-content" role="main">
       <Content />
-    </div>
+    </main>
     <SiteFooter />
   </div>
 </template>


### PR DESCRIPTION
This PR addresses the accessibility issue where the document lacked a main landmark. 

Changes:
- Replaced the generic `div` wrapper around the content with a `main` tag in `Layout.vue`.
- Added `role="main"` to the `main` element.
- Added `role="banner"` to the `header` element in `SiteHeader.vue`.
- Added `role="contentinfo"` to the `footer` element in `SiteFooter.vue`.

Reference: [Deque University - Landmark One Main](https://dequeuniversity.com/rules/axe/4.11/landmark-one-main)