### PR TITLE
Refactor: Replace SCSS with Native CSS

### DIFF
--- a/.vitepress/theme/components/SiteFooter.vue
+++ b/.vitepress/theme/components/SiteFooter.vue
@@ -2,7 +2,7 @@
   <footer class="site-footer">&copy; Kazumi Inada</footer>
 </template>
 
-<style lang="scss" scoped>
+<style scoped>
 .site-footer {
   text-align: center;
   font-size: 0.8rem;

--- a/.vitepress/theme/components/SiteHeader.vue
+++ b/.vitepress/theme/components/SiteHeader.vue
@@ -7,9 +7,7 @@
   </header>
 </template>
 
-<style lang="scss" scoped>
-@use "../styles/media.scss";
-
+<style scoped>
 .site-header {
   display: grid;
   grid-template-columns: 200px auto;
@@ -17,7 +15,7 @@
   width: calc(100vw - 100px);
   font-family: "Questrial", sans-serif;
 
-  @include media.mq {
+  @media (max-width: 600px) {
     margin: 50px auto;
     width: calc(100vw - 40px);
   }
@@ -41,7 +39,7 @@
       font-size: 0.9rem;
     }
 
-    @include media.mq {
+    @media (max-width: 600px) {
       display: none;
     }
   }

--- a/.vitepress/theme/layouts/Layout.vue
+++ b/.vitepress/theme/layouts/Layout.vue
@@ -20,6 +20,6 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style>
 @import "../styles/index.css";
 </style>

--- a/.vitepress/theme/styles/global.css
+++ b/.vitepress/theme/styles/global.css
@@ -137,14 +137,14 @@ body {
   }
 }
 
-// Inline code
+/* Inline code */
 :not(pre) > code {
   background-color: #eee;
   border-radius: 4px;
   padding: 3px 6px;
 }
 
-// Code block
+/* Code block */
 [class*="language-"] {
   position: relative;
   background-color: #333;

--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -1,1 +1,1 @@
-@import "./global.scss";
+@import "./global.css";

--- a/.vitepress/theme/styles/media.scss
+++ b/.vitepress/theme/styles/media.scss
@@ -1,5 +1,0 @@
-@mixin mq {
-  @media (max-width: 600px) {
-    @content;
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,7 @@
       "devDependencies": {
         "lint-staged": ">=10",
         "prettier": "3.0.0",
-        "sass": "1.94.2",
-        "sass-loader": "16.0.6",
         "simple-git-hooks": "2.13.1",
-        "stylus": "0.64.0",
         "vitepress": "1.0.0-rc.29"
       },
       "engines": {
@@ -29,7 +26,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@algolia/abtesting": {
       "version": "1.11.0",
@@ -788,6 +786,7 @@
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -805,7 +804,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
@@ -813,6 +813,7 @@
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -831,6 +832,7 @@
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1916,7 +1918,8 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -1924,6 +1927,7 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1947,6 +1951,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -1996,6 +2001,7 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2008,7 +2014,8 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2033,6 +2040,7 @@
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2055,6 +2063,7 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2086,14 +2095,16 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -2204,6 +2215,7 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -2249,6 +2261,7 @@
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2269,7 +2282,8 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2327,7 +2341,8 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -2335,6 +2350,7 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -2420,7 +2436,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2478,6 +2495,7 @@
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2494,6 +2512,7 @@
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -2520,7 +2539,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nano-spawn": {
       "version": "2.0.0",
@@ -2554,13 +2574,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -2590,7 +2603,8 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2598,6 +2612,7 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2608,6 +2623,7 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -2714,6 +2730,7 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -2788,75 +2805,13 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/sass": {
-      "version": "1.94.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.94.2.tgz",
-      "integrity": "sha512-N+7WK20/wOr7CzA2snJcUSSNTCzeCGUTFY3OgeQP3mZ1aj9NMQ0mSTXwlrnd89j33zzQJGqIN52GIOmYrfq46A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher": "^2.4.1"
-      }
-    },
-    "node_modules/sass-loader": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-      "integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "neo-async": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "@rspack/core": "0.x || 1.x",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "sass": "^1.3.0",
-        "sass-embedded": "*",
-        "webpack": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@rspack/core": {
-          "optional": true
-        },
-        "node-sass": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sax": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -2872,6 +2827,7 @@
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -2885,6 +2841,7 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2949,6 +2906,7 @@
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2997,6 +2955,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3012,6 +2971,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3022,6 +2982,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3032,6 +2993,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3062,6 +3024,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -3075,32 +3038,9 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stylus": {
-      "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
-      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@adobe/css-tools": "~4.3.3",
-        "debug": "^4.3.2",
-        "glob": "^10.4.5",
-        "sax": "~1.4.1",
-        "source-map": "^0.7.3"
-      },
-      "bin": {
-        "stylus": "bin/stylus"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://opencollective.com/stylus"
       }
     },
     "node_modules/tabbable": {
@@ -3265,6 +3205,7 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3300,6 +3241,7 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3318,6 +3260,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3328,6 +3271,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3344,6 +3288,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3354,6 +3299,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3369,6 +3315,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "devDependencies": {
     "lint-staged": ">=10",
     "prettier": "3.0.0",
-    "sass": "1.94.2",
-    "sass-loader": "16.0.6",
     "simple-git-hooks": "2.13.1",
-    "stylus": "0.64.0",
     "vitepress": "1.0.0-rc.29"
   },
   "dependencies": {


### PR DESCRIPTION
This PR removes the dependency on SCSS and migrates the styling to use native CSS nesting and media queries.

Changes:
- Removed `sass`, `sass-loader`, and `stylus` dependencies.
- Converted `global.scss` to `global.css`.
- Removed `media.scss` and replaced mixins with standard `@media` queries in components.
- Updated Vue components to use standard `<style>` tags instead of `<style lang="scss">`.
